### PR TITLE
Set PG-13 Rating of Giphy Client

### DIFF
--- a/src/GiphyClient.php
+++ b/src/GiphyClient.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Client;
 
 final class GiphyClient
 {
-    const QUERY_STRING = '?api_key=%s&s=%s&limit=1';
+    const QUERY_STRING = '?api_key=%s&s=%s&limit=1&rating=pg-13';
 
     /**
      * @var Client


### PR DESCRIPTION
### Explanation

Set's the rating of giphy requests to PG-13
