### PR TITLE
Disabled the simplifying of the math parser

### DIFF
--- a/app/Handlers/Utility/CalculateHandler.php
+++ b/app/Handlers/Utility/CalculateHandler.php
@@ -23,12 +23,14 @@ final class CalculateHandler extends Handler
     private $calculator;
 
     /**
+     * @param JsonLoader $loader
      * @param Calculator $calculator
      */
     public function __construct(JsonLoader $loader, Calculator $calculator)
     {
         $this->loader     = $loader;
         $this->calculator = $calculator;
+        $this->calculator->setSimplifying(false);
     }
 
     /**


### PR DESCRIPTION
### Explanation

This disables the simplifier of Mossadal's math parser library, as described by himself [here](https://github.com/mossadal/math-parser/issues/2).

Fixes #30 
