### PR TITLE
added laravel command for simple doc search

### DIFF
--- a/app/Handlers/Reference/LaravelHandler.php
+++ b/app/Handlers/Reference/LaravelHandler.php
@@ -45,12 +45,12 @@ final class LaravelHandler extends Handler
 
         $words = explode(' ',$event->text());
 
-        if(in_array($words[1], $versions)) {
-            $version = $words[1];
-            $query = $words[2];
+        if(in_array($words[2], $versions)) {
+            $version = $words[2];
+            $query = $words[3];
         } else {
-            $version = '5.3';
-            $query = $words[1];
+            $version = $versions[1];
+            $query = $words[2];
         }
 
         try {

--- a/app/Handlers/Reference/LaravelHandler.php
+++ b/app/Handlers/Reference/LaravelHandler.php
@@ -37,7 +37,7 @@ final class LaravelHandler extends Handler
         return
             $event->isMessage() &&
             ($event->isDirectMessage() || $event->mentions($this->eve->userId())) &&
-            $event->matches('/\b(laravel)\b/i')
+            $event->matches('/laravel .+/i')
         ;
     }
 

--- a/app/Handlers/Reference/LaravelHandler.php
+++ b/app/Handlers/Reference/LaravelHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Handlers\Reference;
+
+use App\Slack\Event;
+use App\Slack\Message;
+use App\Handlers\Handler;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+
+final class LaravelHandler extends Handler
+{
+
+    private $client;
+
+    /**
+     * Loads GuzzleHttp Client.
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canHandle(Event $event)
+    {
+        return
+            $event->isMessage() &&
+            ($event->isDirectMessage() || $event->mentions($this->eve->userId())) &&
+            $event->matches('/\b(laravel)\b/i')
+            ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Event $event)
+    {
+        $versions = [
+            'master', '5.3', '5.2', '5.1', '5.0', '4.2'
+        ];
+
+        $words = explode(' ',$event->text());
+
+        if(in_array($words[1], $versions)) {
+            $version = $words[1];
+            $query = $words[2];
+        } else {
+            $version = '5.3';
+            $query = $words[1];
+        }
+
+        try {
+            $url = "https://laravel.com/docs/$version/$query";
+            $this->client->get($url);
+            $reply = $url;
+        } catch (ClientException $e) {
+            $reply = 'Could not find the documentation for *'.$query.'*';
+        }
+
+        $this->send(
+            Message::saying($reply)
+                ->inChannel($event->channel())
+                ->to($event->sender())
+        );
+    }
+}
+

--- a/app/Handlers/Utility/HelpHandler.php
+++ b/app/Handlers/Utility/HelpHandler.php
@@ -43,6 +43,7 @@ eight ball - see the future with Eve             - @eve 8-ball
 calculate  - run a calculation                   - @eve calculate 2x + 3y --x=2 --y=4
 giphy      - get a random related GIF from Giphy - @eve giphy test
 help       - show list of available commands     - @eve help
+laravel    - search the laravel docs             - @eve laravel middleware
 ```
 
 Contributions are welcomed and encouraged.

--- a/config/eve.php
+++ b/config/eve.php
@@ -15,6 +15,7 @@ return [
         App\Handlers\Media\GiphyHandler::class,
         App\Handlers\Moderation\WarnHandler::class,
         App\Handlers\Moderation\UserJoinsChannelHandler::class,
+        App\Handlers\Reference\LaravelHandler::class,
         App\Handlers\Utility\PingHandler::class,
         App\Handlers\Utility\CalculateHandler::class,
         App\Handlers\Utility\HelpHandler::class


### PR DESCRIPTION
### Explanation

Add an `@eve laravel` command that for now does a quick search through the laravel docs.
Examples:
`@eve laravel middleware` returns a link to the Laravel 5.3 docs for middleware
`@eve laravel 5.2 middleware` returns a link to the Laravel 5.2 docs for middleware

Fixes #29 
