### PR TITLE
add weather command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,5 @@ EVE_SLACK_TOKEN=secret
 
 GIPHY_BASE_URL=http://example.com
 GIPHY_API_KEY=secret
+
+OWM_API_KEY=

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ When contributing code, testing is strongly encouraged: the more we can test now
 ### Contributors
 A number of people have helped Eve to come this far. In no particular order:
 
+- [Alexander Hjorth](https://github.com/ahjorth) (`@pistachio` on Larachat)
 - [Andreas Elia](https://github.com/andreaselia) (`@andreaselia` on Larachat)
 - [Apostolos Spanos](https://github.com/apspan)
 - [Brett Taylor](https://github.com/glutnix) (`@glutnix` on Larachat)

--- a/app/Client/WeatherClient.php
+++ b/app/Client/WeatherClient.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Client;
+
+use Cmfcmf\OpenWeatherMap;
+use Cmfcmf\OpenWeatherMap\Exception as OWMException;
+
+final class WeatherClient
+{
+    /**
+     * @var OpenWeatherMap
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @var string
+     */
+    private $unit;
+
+    /**
+     * @param $apiKey
+     * @internal param OpenWeatherMap $client
+     */
+    public function __construct($apiKey)
+    {
+        $this->client  = new OpenWeatherMap($apiKey);
+        $this->apiKey  = $apiKey;
+    }
+
+    /**
+     * @param string $query
+     * @param string $unit
+     * @param string $language
+     *
+     * @return null|string
+     */
+    public function getWeather($query, $unit, $language)
+    {
+        $unit == 'metric' ? $this->unit = 'C' : $this->unit = 'F';
+
+        try {
+            $result = $this->client->getWeather($query, $unit, $language);
+            $response = '*'.$result->city->name.'* has *'.$result->weather->description.
+                            '* and a temperature of *'.$result->temperature->now->getValue().$this->unit.'*';
+        } catch(OWMException $e) {
+            $response = "Sorry, I can't find that place";
+        } catch(\Exception $e) {
+            $response = "Unknown Error";
+        }
+        return $response;
+    }
+
+}

--- a/app/Handlers/Utility/HelpHandler.php
+++ b/app/Handlers/Utility/HelpHandler.php
@@ -33,18 +33,19 @@ Send commands to Eve via mentioning or direct message.
 Currently, Eve supports the following commands:
 
 ```
-hello      - say hello to Eve                    - hello @eve
-thanks     - send a thank you to Eve             - thanks, @eve
-ping       - ping Eve, get a pong back           - ping @eve
-pun        - get Eve to say a pun                - @eve pun
-sandwich   - ask Eve to make you a sandwich      - @eve make me a sandwhich
-slap       - tell Eve to slap someone for you    - @eve slap @someone
-eight ball - see the future with Eve             - @eve 8-ball
-calculate  - run a calculation                   - @eve calculate 2x + 3y --x=2 --y=4
-giphy      - get a random related GIF from Giphy - @eve giphy test
-help       - show list of available commands     - @eve help
-laravel    - search the laravel docs             - @eve laravel middleware
-imdb       - search for a movie on imdb          - @eve imdb the matrix
+hello      - say hello to Eve                       - hello @eve
+thanks     - send a thank you to Eve                - thanks, @eve
+ping       - ping Eve, get a pong back              - ping @eve
+pun        - get Eve to say a pun                   - @eve pun
+sandwich   - ask Eve to make you a sandwich         - @eve make me a sandwhich
+slap       - tell Eve to slap someone for you       - @eve slap @someone
+eight ball - see the future with Eve                - @eve 8-ball
+calculate  - run a calculation                      - @eve calculate 2x + 3y --x=2 --y=4
+giphy      - get a random related GIF from Giphy    - @eve giphy test
+help       - show list of available commands        - @eve help
+laravel    - search the laravel docs                - @eve laravel middleware
+imdb       - search for a movie on imdb             - @eve imdb the matrix
+weather    - get the current weather for a location - @eve weather chicago
 ```
 
 Contributions are welcomed and encouraged.

--- a/app/Handlers/Utility/WeatherHandler.php
+++ b/app/Handlers/Utility/WeatherHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Handlers\Utility;
+
+use App\Client\WeatherClient;
+use App\Slack\Event;
+use App\Slack\Message;
+use App\Handlers\Handler;
+use Illuminate\Support\Collection;
+
+final class WeatherHandler extends Handler
+{
+    /**
+     * @var WeatherClient
+     */
+    private $client;
+
+    /**
+     * @var array
+     */
+    private static $units = [
+        'metric', 'imperial'
+    ];
+
+    const DEFAULT_UNIT = 'imperial';
+    const DEFAULT_LANGUAGE = 'en';
+
+    /**
+     * @param WeatherClient $client
+     */
+    public function __construct(WeatherClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canHandle(Event $event)
+    {
+        return
+            $event->isMessage() &&
+            ($event->isDirectMessage() || $event->mentions($this->eve->userId())) &&
+            $event->matches('/weather .+/i')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Event $event)
+    {
+
+        $parameters = $this->getParameters($event);
+        $query      = $this->getQuery($parameters);
+        $unit       = $this->getUnit($parameters);
+
+        $query ?
+            $response = $this->client->getWeather($query, $unit, self::DEFAULT_LANGUAGE) :
+            $response = 'Please provide me with a location. Like `weather chicago '.$unit.'`';
+
+        $this->send(
+            Message::saying($response)
+                ->inChannel($event->channel())
+                ->to($event->sender())
+        );
+    }
+
+    /**
+     * @param Event $event
+     *
+     * @return array
+     */
+    private function getParameters(Event $event)
+    {
+        return explode(' ', substr($event->text(), strpos($event->text(), 'weather ') + 8));
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string
+     */
+    private function getUnit(array $parameters)
+    {
+        $unit = self::DEFAULT_UNIT;
+        collect($parameters)->each(function ($parameter) use (&$unit) {
+            if (in_array($parameter, self::$units)) {
+                $unit = $parameter;
+            }
+        });
+
+        return $unit;
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string|null
+     */
+    private function getQuery(array $parameters)
+    {
+        $query = new Collection();
+
+        collect($parameters)->each(function ($parameter) use (&$query) {
+            if (!in_array($parameter, self::$units)) {
+                $query->push($parameter);
+            }
+        });
+
+        return $query->implode(' ') ?: null;
+    }
+}
+

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Bots\Eve;
 use App\Client\GiphyClient;
+use App\Client\WeatherClient;
 use App\Handlers\HandlerManager;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
@@ -19,6 +20,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->when(GiphyClient::class)->needs('$baseUrl')->give($this->app['config']->get('eve.services.giphy.base_url'));
         $this->app->when(GiphyClient::class)->needs('$apiKey')->give($this->app['config']->get('eve.services.giphy.api_key'));
+        $this->app->when(WeatherClient::class)->needs('$apiKey')->give($this->app['config']->get('eve.services.weather.api_key'));
 
         $this->app->bind(HandlerManager::class, function ($app) {
             $handlers = new Collection();

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "coderstephen/slack-client": "^0.2.5",
         "guzzlehttp/guzzle": "^6.2",
         "mossadal/math-parser": "^1.2",
-        "jleagle/omdb-imdb-api-client": "^0.1.0"
+        "jleagle/omdb-imdb-api-client": "^0.1.0",
+        "cmfcmf/openweathermap-php-api": "^2.1"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d2a67adb29f3948e3973524c832c2a0f",
-    "content-hash": "947ea875f5988f1117ee18b54243c63c",
+    "hash": "ad2563219d791bd99130a1436e1eda73",
+    "content-hash": "e067c4897540734a709e44266018cceb",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -60,6 +60,50 @@
                 "preload"
             ],
             "time": "2015-11-09 22:51:51"
+        },
+        {
+            "name": "cmfcmf/openweathermap-php-api",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cmfcmf/OpenWeatherMap-PHP-Api.git",
+                "reference": "31465dc48b46d5273cb3ca1e559c1eb801665011"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cmfcmf/OpenWeatherMap-PHP-Api/zipball/31465dc48b46d5273cb3ca1e559c1eb801665011",
+                "reference": "31465dc48b46d5273cb3ca1e559c1eb801665011",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cmfcmf\\": "Cmfcmf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Flach (cmfcmf)",
+                    "email": "cmfcmf.flach@gmail.com",
+                    "homepage": "http://cmfcmf.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A php api to parse weather data from OpenWeatherMap.org. This api tries to normalise and abstract the data and remove inconsistencies.",
+            "homepage": "https://github.com/cmfcmf/OpenWeatherMap-PHP-Api",
+            "keywords": [
+                "OpenWeatherMap",
+                "weather",
+                "weather api"
+            ],
+            "time": "2016-10-17 10:03:11"
         },
         {
             "name": "coderstephen/slack-client",

--- a/config/eve.php
+++ b/config/eve.php
@@ -19,7 +19,8 @@ return [
         App\Handlers\Reference\ImdbHandler::class,
         App\Handlers\Utility\PingHandler::class,
         App\Handlers\Utility\CalculateHandler::class,
-        App\Handlers\Utility\HelpHandler::class
+        App\Handlers\Utility\HelpHandler::class,
+        App\Handlers\Utility\WeatherHandler::class
     ],
 
     'services' => [
@@ -27,5 +28,8 @@ return [
             'base_url' => env('GIPHY_BASE_URL'),
             'api_key'  => env('GIPHY_API_KEY'),
         ],
+        'weather' => [
+            'api_key' => env('OWM_API_KEY'),
+        ]
     ],
 ];


### PR DESCRIPTION
### Explanation

Adds a weather command to eve.
Use it with the command `@eve weather location`
By default, the unit of measurement will be `imperial` but `metric` can be specified anywhere in the query after the `weather` command, e.g:
`@eve weather metric chicago`
`@eve weather seattle metric`

_Be aware: API key for https://openweathermap.org/ needs to be inserted into `.env`_

Fixes #9 
