### PR TITLE
move to apixu api for weather

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,4 +36,5 @@ EVE_SLACK_TOKEN=secret
 GIPHY_BASE_URL=http://example.com
 GIPHY_API_KEY=secret
 
-OWM_API_KEY=
+APIXU_BASE_URL=http://example.com
+APIXU_API_KEY=secret

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use App\Bots\Eve;
-use Cmfcmf\OpenWeatherMap;
 use App\Client\GiphyClient;
 use App\Client\WeatherClient;
 use App\Handlers\HandlerManager;
@@ -21,17 +20,14 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->when(GiphyClient::class)->needs('$baseUrl')->give($this->app['config']->get('eve.services.giphy.base_url'));
         $this->app->when(GiphyClient::class)->needs('$apiKey')->give($this->app['config']->get('eve.services.giphy.api_key'));
-        
-        $this->app->bind(WeatherClient::class, function ($app) {
-            return new WeatherClient(
-                new OpenWeatherMap($this->app['config']->get('eve.services.weather.api_key'))
-            );
-        });
+
+        $this->app->when(WeatherClient::class)->needs('$baseUrl')->give($this->app['config']->get('eve.services.weather.base_url'));
+        $this->app->when(WeatherClient::class)->needs('$apiKey')->give($this->app['config']->get('eve.services.weather.api_key'));
 
         $this->app->bind(HandlerManager::class, function ($app) {
             $handlers = new Collection();
             
-            foreach($app['config']->get('eve.handlers') as $handler) {
+            foreach ($app['config']->get('eve.handlers') as $handler) {
                 $handlers->push($app->make($handler));
             }
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "coderstephen/slack-client": "^0.2.5",
         "guzzlehttp/guzzle": "^6.2",
         "mossadal/math-parser": "^1.3",
-        "jleagle/omdb-imdb-api-client": "^0.1.0",
-        "cmfcmf/openweathermap-php-api": "^2.1"
+        "jleagle/omdb-imdb-api-client": "^0.1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/config/eve.php
+++ b/config/eve.php
@@ -29,7 +29,8 @@ return [
             'api_key'  => env('GIPHY_API_KEY'),
         ],
         'weather' => [
-            'api_key' => env('OWM_API_KEY'),
+            'base_url' => env('APIXU_BASE_URL'),
+            'api_key' => env('APIXU_API_KEY'),
         ]
     ],
 ];


### PR DESCRIPTION
This PR changes the current weather API from OpenWeatherMap to Apixu.

An Apixu api token is required, gained from signing up at apixu.com
The base URL should be *http://api.apixu.com/v1*

Fixes #47

